### PR TITLE
[9.x] Don't use locks for queue job popping for PlanetScale's MySQL-compatible Vitess engine

### DIFF
--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -261,7 +261,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
         if (Str::of($databaseVersion)->contains('MariaDB')) {
             $databaseEngine = 'mariadb';
             $databaseVersion = Str::before(Str::after($databaseVersion, '5.5.5-'), '-');
-        } else if (Str::of($databaseVersion)->contains('vitess')) {
+        } elseif (Str::of($databaseVersion)->contains('vitess')) {
             $databaseEngine = 'vitess';
             $databaseVersion = Str::before($databaseVersion, '-');
         }


### PR DESCRIPTION
PlanetScale provides great serverless MySQL-compatible database and guide on how to integrate it in Laravel (https://planetscale.com/docs/tutorials/connect-laravel-app) but under hood uses Vitess.

However it looks that Vitess doesn't support "skip" queries:
```SQLSTATE[HY000]: General error: 1105 syntax error at position 185 near 'SKIP' (SQL: select * from `jobs` where `queue` = default and ((`reserved_at` is null and `available_at` <= 1662479913) or (`reserved_at` <= 1662479823)) order by `id` asc limit 1 FOR UPDATE SKIP LOCKED)```

Following https://github.com/laravel/framework/issues/31536 I've added a check for Vitess engine/version parsing so it wouldn't use locks for popping:
```>>> DB::connection()->getPdo()->getAttribute(PDO::ATTR_DRIVER_NAME)
=> "mysql"

>>> DB::connection()->getPdo()->getAttribute(PDO::ATTR_SERVER_VERSION)
=> "8.0.23-vitess"```

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
